### PR TITLE
demo(s2): raise routing coverage threshold to 85

### DIFF
--- a/policy/routing.json
+++ b/policy/routing.json
@@ -1,10 +1,11 @@
 {
   "routing": [
     { "path": "src/auth/**", "apply": ["core-l1", "quality-l2"], "coverage": 80 },
-    { "path": "src/**", "apply": ["core-l1"], "coverage": 60 },
-    { "path": "src/utils/**", "apply": ["core-l1"], "coverage": 60 }
+    { "path": "src/**", "apply": ["core-l1"], "coverage": 85 },
+    { "path": "src/utils/**", "apply": ["core-l1"], "coverage": 85 }
   ],
   "exceptions": [
     { "path": "tests/fixtures/**", "rules": ["IR-003"], "expires": "2025-11-01" }
   ]
 }
+


### PR DESCRIPTION
# PR 说明
\n标题：docs: bootstrap (demo PR)
\n\n做了什么：初始化项目材料与脚本
\n为什么这么做：建立可持续的单窗口执行与强制规则体系
\n影响范围：文档/脚本/配置
\n回滚策略：参考 回滚策略模板.md
\n关联登记：开发跟进记录.md、阶段登记表.md
